### PR TITLE
chore: Add Go lint check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest


### PR DESCRIPTION
## What changed

Adds [golangci-lint-action](https://github.com/golangci/golangci-lint-action) on CI to run on every PR.

<img width="935" alt="CleanShot 2023-03-29 at 10 03 02@2x" src="https://user-images.githubusercontent.com/1369770/228614414-8062cdb7-0a58-41b7-b7cc-33dca6f419a3.png">


Hooray! 🥳 CI is working! We have a ❌, yes, that we’ll need to turn into a ✅. But that will be @Bobs-code’s job to fix 😉 

## How to review

CI should now run linting (even on this PR). See Actions workflow.